### PR TITLE
ix & feat(dashboard): null-safe overview, working subscription flag, friendlier new-user state

### DIFF
--- a/src/app/core/models/dashboard.model.ts
+++ b/src/app/core/models/dashboard.model.ts
@@ -37,4 +37,42 @@ export interface IProviderDashboardOverview {
     time: { from: string; to: string };
   };
   activeServiceCount: number;
+  nextBooking: IUpcomingBooking | null;
+  upcomingBookingCount: number;
+  recentBookings: IDashboardRecentBooking[];
+  wallet: { balance: number } | null;
+}
+
+export interface IUpcomingBooking {
+  bookingId: string;
+  amount: number;
+  status: string;
+  slot: { from: string; to: string; date: string };
+  customer: {
+    id: string;
+    username: string;
+    fullname: string;
+    avatar: string;
+  };
+  service: {
+    name: string;
+    category: string;
+  };
+}
+
+export interface IDashboardRecentBooking {
+  bookingId: string;
+  amount: number;
+  status: string;
+  date: string;
+  customer: {
+    id: string;
+    username: string;
+    fullname: string;
+    avatar: string;
+  };
+  service: {
+    name: string;
+    category: string;
+  };
 }

--- a/src/app/modules/pages/provider/provider-homepage/provider-homepage.component.html
+++ b/src/app/modules/pages/provider/provider-homepage/provider-homepage.component.html
@@ -1,20 +1,99 @@
-<main class="space-y-8 px-2 py-4">
+<main class="space-y-6 px-2 py-4">
 
-  <!-- Overview Section -->
-  <section>
-    <h2 class="text-lg sm:text-xl font-semibold text-gray-800 mb-5">
-      Overview
-    </h2>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 sm:gap-5">
-      <ng-container *ngFor="let card of overviewCards">
-        <app-provider-overview-cards [data]="card"></app-provider-overview-cards>
-      </ng-container>
+  <!-- Loading -->
+  <app-dashboard-skeleton *ngIf="loading"></app-dashboard-skeleton>
+
+  <!-- Error -->
+  <ng-container *ngIf="!loading && error">
+    <div class="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
+      <div class="flex flex-col items-center justify-center py-16 text-center">
+        <div class="mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-red-50 text-red-500">
+          <i class="fa-solid fa-triangle-exclamation text-xl"></i>
+        </div>
+        <h2 class="mb-2 text-lg font-semibold text-slate-900">Unable to load dashboard</h2>
+        <p class="mb-6 text-sm text-slate-500">Something went wrong while loading your dashboard.</p>
+        <button type="button" (click)="retry()"
+          class="rounded-lg bg-emerald-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2">
+          Try Again
+        </button>
+      </div>
     </div>
-  </section>
+  </ng-container>
 
-  <!-- Recent Bookings Section -->
-  <section>
-    <app-provider-booking-recent [showFilters]="false" [actionable]="false"></app-provider-booking-recent>
-  </section>
+  <!-- Success -->
+  <ng-container *ngIf="!loading && !error && data">
+
+    <!-- Welcome / Today Header -->
+    <app-dashboard-header [providerName]="providerName" [upcomingCount]="data!.upcomingBookingCount"
+      [nextBookingTime]="nextBookingTime">
+    </app-dashboard-header>
+
+    <!-- New Provider Onboarding -->
+    <section *ngIf="isNewProvider" aria-label="Get started"
+      class="overflow-hidden rounded-2xl bg-gradient-to-br from-emerald-600 to-teal-700 text-white shadow-sm ring-1 ring-emerald-700">
+      <div class="p-6 sm:p-8">
+        <div class="mb-2 inline-flex items-center gap-2 rounded-full bg-white/15 px-3 py-1 text-xs font-semibold">
+          <i class="fa-solid fa-sparkles"></i> Welcome to Homeserve
+        </div>
+        <h2 class="text-xl font-bold sm:text-2xl">Let's set up your business, {{ providerName }}</h2>
+        <p class="mt-1 max-w-2xl text-sm text-emerald-50">
+          A few quick steps and you'll be ready to accept your first booking. Here's what to do next:
+        </p>
+
+        <div class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div *ngFor="let step of welcomeSteps"
+            class="flex flex-col rounded-xl bg-white/10 p-4 ring-1 ring-white/20 backdrop-blur-sm">
+            <div class="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-white/15">
+              <i [class]="step.icon" class="text-base"></i>
+            </div>
+            <p class="text-sm font-semibold">{{ step.title }}</p>
+            <p class="mt-1 flex-1 text-xs text-emerald-50/90">{{ step.description }}</p>
+            <a [routerLink]="step.link"
+              class="mt-4 inline-flex items-center justify-center gap-1.5 rounded-lg bg-white px-3 py-2 text-xs font-semibold text-emerald-700 transition-colors hover:bg-emerald-50">
+              {{ step.cta }}
+              <i class="fa-solid fa-arrow-right"></i>
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Primary KPI Snapshot -->
+    <section aria-label="Key metrics">
+      <app-kpi-card-grid>
+        <app-kpi-card *ngFor="let kpi of kpis" [label]="kpi.label" [value]="kpi.value" [unit]="kpi.unit"
+          [icon]="kpi.icon" [tone]="kpi.tone" [description]="kpi.description">
+        </app-kpi-card>
+      </app-kpi-card-grid>
+    </section>
+
+    <!-- Today's Activity / Next Booking + Availability -->
+    <section class="grid grid-cols-1 gap-6 lg:grid-cols-3" aria-label="Today's activity">
+      <div class="lg:col-span-2">
+        <app-next-booking-card [nextBooking]="data!.nextBooking" [nextAvailableSlot]="data!.nextAvailableSlot">
+        </app-next-booking-card>
+      </div>
+      <app-dashboard-availability-card [workingHours]="data!.workingHours"
+        [activeServiceCount]="data!.activeServiceCount" [nextBookingTime]="nextBookingTime">
+      </app-dashboard-availability-card>
+    </section>
+
+    <!-- Recent Bookings -->
+    <section aria-label="Recent bookings">
+      <app-recent-bookings-preview [bookings]="data!.recentBookings"></app-recent-bookings-preview>
+    </section>
+
+    <!-- Performance + Attention -->
+    <section class="grid grid-cols-1 gap-6 lg:grid-cols-2" aria-label="Performance and attention">
+      <app-dashboard-performance-card [avgRating]="data!.avgRating" [completionRate]="data!.completionRate">
+      </app-dashboard-performance-card>
+      <app-dashboard-attention-card [pendingCount]="data!.revenue.pendingCount"
+        [cancelledCount]="data!.bookings.cancelledBookings" [upcomingCount]="data!.bookings.upcomingBookings"
+        [activeServiceCount]="data!.activeServiceCount" [verificationVerified]="verificationVerified"
+        [hasSubscription]="hasSubscription">
+      </app-dashboard-attention-card>
+    </section>
+
+  </ng-container>
 
 </main>

--- a/src/app/modules/pages/provider/provider-homepage/provider-homepage.component.ts
+++ b/src/app/modules/pages/provider/provider-homepage/provider-homepage.component.ts
@@ -1,197 +1,198 @@
 import { Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { SharedDataService } from '../../../../core/services/public/shared-data.service';
-import { ProviderOverviewCardsComponent } from '../../../shared/partials/sections/provider/overview-cards/overview-cards.component';
-import { IProviderDashboardOverview, OverviewCardData } from '../../../../core/models/dashboard.model';
-import { ProviderService } from '../../../../core/services/provider.service';
+import { RouterLink } from '@angular/router';
+import { Store } from '@ngrx/store';
 import { Subject, takeUntil } from 'rxjs';
-import { ProviderBookingRecentComponent } from '../../../shared/components/provider/bookings/bookings-recent/booking-recent.component';
+import { SharedDataService } from '../../../../core/services/public/shared-data.service';
+import { ProviderService } from '../../../../core/services/provider.service';
+import { SubscriptionService } from '../../../../core/services/subscription.service';
+import { IProviderDashboardOverview } from '../../../../core/models/dashboard.model';
+import { selectProvider } from '../../../../store/provider/provider.selector';
+import { DashboardHeaderComponent } from '../../../shared/components/provider/dashboard/dashboard-header/dashboard-header.component';
+import { NextBookingCardComponent } from '../../../shared/components/provider/dashboard/next-booking-card/next-booking-card.component';
+import { DashboardAvailabilityCardComponent } from '../../../shared/components/provider/dashboard/dashboard-availability-card/dashboard-availability-card.component';
+import { RecentBookingsPreviewComponent } from '../../../shared/components/provider/dashboard/recent-bookings-preview/recent-bookings-preview.component';
+import { DashboardPerformanceCardComponent } from '../../../shared/components/provider/dashboard/dashboard-performance-card/dashboard-performance-card.component';
+import { DashboardAttentionCardComponent } from '../../../shared/components/provider/dashboard/dashboard-attention-card/dashboard-attention-card.component';
+import { DashboardSkeletonComponent } from '../../../shared/components/provider/dashboard/dashboard-skeleton/dashboard-skeleton.component';
+import { KpiCardComponent, KpiTone } from '../../../shared/components/analytics/kpi-card/kpi-card.component';
+import { KpiCardGridComponent } from '../../../shared/components/analytics/kpi-card-grid/kpi-card-grid.component';
 
 @Component({
   selector: 'app-provider-homepage',
   templateUrl: './provider-homepage.component.html',
   imports: [
     CommonModule,
-    ProviderOverviewCardsComponent,
-    ProviderBookingRecentComponent
-  ]
+    RouterLink,
+    DashboardHeaderComponent,
+    NextBookingCardComponent,
+    DashboardAvailabilityCardComponent,
+    RecentBookingsPreviewComponent,
+    DashboardPerformanceCardComponent,
+    DashboardAttentionCardComponent,
+    DashboardSkeletonComponent,
+    KpiCardComponent,
+    KpiCardGridComponent,
+  ],
 })
 export class ProviderHomepageComponent implements OnInit, OnDestroy {
   private readonly _sharedService = inject(SharedDataService);
   private readonly _providerService = inject(ProviderService);
-
+  private readonly _subscriptionService = inject(SubscriptionService);
+  private readonly _store = inject(Store);
   private _destroy$ = new Subject<void>();
 
-  overviewCards: OverviewCardData[] = [];
+  loading = true;
+  error = false;
+  data: IProviderDashboardOverview | null = null;
+
+  providerName = 'Provider';
+  verificationVerified = true;
+  hasSubscription = true;
 
   ngOnInit(): void {
     this._sharedService.setProviderHeader('Dashboard');
 
+    this._store.select(selectProvider)
+      .pipe(takeUntil(this._destroy$))
+      .subscribe((provider) => {
+        this.providerName = provider?.fullname || provider?.username || 'Provider';
+        this.verificationVerified = provider?.verificationStatus === 'verified';
+      });
+
+    this._subscriptionService.hasActiveSubscription()
+      .pipe(takeUntil(this._destroy$))
+      .subscribe({
+        next: (res) => (this.hasSubscription = !!res?.success),
+        error: () => (this.hasSubscription = false),
+      });
+
+    this._load();
+  }
+
+  private _load(): void {
+    this.loading = true;
+    this.error = false;
+
     this._providerService.getDashboardOverview()
       .pipe(takeUntil(this._destroy$))
       .subscribe({
-        next: (res) => {
-          this.overviewCards = this._buildOverviewCards(res.data);
+        next: (res: any) => {
+          this.data = res?.data ?? null;
+          this.loading = false;
         },
-        error: (err) => {
-          console.error('Error fetching dashboard overview:', err);
+        error: () => {
+          this.data = null;
+          this.loading = false;
+          this.error = true;
         },
       });
   }
 
-  private _buildOverviewCards(data: IProviderDashboardOverview): OverviewCardData[] {
+  retry(): void {
+    this._load();
+  }
+
+  // ---- Derived values passed to children ----
+
+  get nextBookingTime(): string {
+    const slot = this.data?.nextBooking?.slot;
+    if (slot?.from) return this._fmtTime(slot.from);
+    const fallback = this.data?.nextAvailableSlot;
+    return fallback?.from ? this._fmtTime(fallback.from) : '';
+  }
+
+  get isNewProvider(): boolean {
+    const d = this.data;
+    if (!d) return false;
+    const totalBookings = d.bookings?.totalBookings ?? 0;
+    return d.activeServiceCount === 0 && totalBookings === 0 && d.recentBookings.length === 0;
+  }
+
+  get welcomeSteps(): { icon: string; title: string; description: string; link: string[]; cta: string }[] {
+    const steps = [];
+    if (!this.verificationVerified) {
+      steps.push({
+        icon: 'fa-solid fa-id-card',
+        title: 'Get verified',
+        description: 'Complete your document verification to win customer trust.',
+        link: ['/provider/profiles'],
+        cta: 'Verify now',
+      });
+    }
+    if (!this.hasSubscription) {
+      steps.push({
+        icon: 'fa-solid fa-crown',
+        title: 'Pick a plan',
+        description: 'Choose a subscription plan to start accepting bookings.',
+        link: ['/provider/plans'],
+        cta: 'View plans',
+      });
+    }
+    steps.push(
+      {
+        icon: 'fa-solid fa-layer-group',
+        title: 'Add your services',
+        description: 'List what you offer so customers can find and book you.',
+        link: ['/provider/manage-services'],
+        cta: 'Add services',
+      },
+      {
+        icon: 'fa-solid fa-calendar-days',
+        title: 'Set your availability',
+        description: 'Tell customers when you are free to take bookings.',
+        link: ['/provider/availability'],
+        cta: 'Set availability',
+      },
+    );
+    return steps;
+  }
+
+  get kpis(): { label: string; value: string | number; unit?: string; icon: string; tone: KpiTone; description?: string }[] {
+    const d = this.data;
+    if (!d) return [];
+    const revenue = d.revenue ?? {};
+    const bookings = d.bookings ?? {};
+    const walletBalance = d.wallet?.balance ?? null;
     return [
       {
-        heading: 'Earnings Overview',
-        boxes: [
-          {
-            title: 'Total Earnings',
-            icon: 'fa-dollar-sign',
-            iconColorClass: 'text-green-600',
-            value: `₹${data.revenue.totalEarnings.toFixed(2)}`,
-            valueColorClass: 'text-gray-800',
-            bgColorClass: 'bg-green-50',
-            borderColorClass: 'border-green-100',
-          },
-          {
-            title: 'Pending',
-            icon: 'fa-clock',
-            iconColorClass: 'text-orange-600',
-            value: data.revenue.pendingCount,
-            valueColorClass: 'text-orange-600',
-            bgColorClass: 'bg-orange-50',
-            borderColorClass: 'border-orange-100',
-          },
-          {
-            title: 'Completed',
-            icon: 'fa-check',
-            iconColorClass: 'text-blue-600',
-            value: data.revenue.completedCount,
-            valueColorClass: 'text-blue-600',
-            bgColorClass: 'bg-blue-50',
-            borderColorClass: 'border-blue-100',
-          },
-        ],
-        detailsText: 'View Details',
-        detailsLinkOrCallback: '/earnings/details',
+        label: 'Total Earnings',
+        value: (revenue.totalEarnings ?? 0).toLocaleString('en-IN', { maximumFractionDigits: 2 }),
+        unit: '₹',
+        icon: 'fa-solid fa-indian-rupee-sign',
+        tone: 'positive',
+        description: walletBalance != null && !this.isNewProvider ? `Wallet balance ₹${walletBalance.toLocaleString('en-IN')}` : undefined,
       },
       {
-        heading: 'Bookings Overview',
-        boxes: [
-          {
-            title: 'Total Bookings',
-            icon: 'fa-calendar-alt',
-            iconColorClass: 'text-green-700',
-            value: data.bookings?.totalBookings ?? 0,
-            valueColorClass: 'text-gray-800',
-            bgColorClass: 'bg-green-50',
-            borderColorClass: 'border-green-100',
-          },
-          {
-            title: 'Upcoming',
-            icon: 'fa-hourglass-half',
-            iconColorClass: 'text-yellow-500',
-            value: data.bookings?.upcomingBookings ?? 0,
-            valueColorClass: 'text-yellow-600',
-            bgColorClass: 'bg-yellow-50',
-            borderColorClass: 'border-yellow-100',
-          },
-          {
-            title: 'Cancelled',
-            icon: 'fa-times-circle',
-            iconColorClass: 'text-red-600',
-            value: data.bookings?.cancelledBookings ?? 0,
-            valueColorClass: 'text-red-600',
-            bgColorClass: 'bg-red-50',
-            borderColorClass: 'border-red-100',
-          },
-        ],
-        detailsText: 'View All',
-        detailsLinkOrCallback: '/bookings/details',
+        label: 'Pending',
+        value: revenue.pendingCount ?? 0,
+        icon: 'fa-solid fa-hourglass-half',
+        tone: 'warning',
       },
       {
-        heading: 'Performance Overview',
-        boxes: [
-          {
-            title: 'Average Rating',
-            icon: 'fa-star',
-            iconColorClass: 'text-yellow-500',
-            value: data.avgRating,
-            valueColorClass: 'text-yellow-600',
-            bgColorClass: 'bg-yellow-50',
-            borderColorClass: 'border-yellow-100',
-          },
-          {
-            title: 'Completion Rate',
-            icon: 'fa-chart-line',
-            iconColorClass: 'text-blue-600',
-            value: data.completionRate.toFixed(2) + '%',
-            valueColorClass: 'text-blue-600',
-            bgColorClass: 'bg-blue-50',
-            borderColorClass: 'border-blue-100',
-          },
-        ],
-        detailsText: 'View Details',
-        detailsLinkOrCallback: '/reviews',
+        label: 'Upcoming Bookings',
+        value: bookings.upcomingBookings ?? 0,
+        icon: 'fa-solid fa-calendar-check',
+        tone: 'info',
       },
       {
-        heading: 'Availability Overview',
-        boxes: [
-          {
-            title: 'Next Booking',
-            icon: 'fa-bell',
-            iconColorClass: 'text-purple-600',
-            value: this._formatNextSlot(data.nextAvailableSlot),
-            valueColorClass: 'text-purple-600',
-            bgColorClass: 'bg-purple-50',
-            borderColorClass: 'border-purple-100',
-          },
-          {
-            title: 'Working Hours',
-            icon: 'fa-clock',
-            iconColorClass: 'text-green-600',
-            value: data.workingHours ? `${data.workingHours?.time?.from || 0} - ${data.workingHours?.time?.to || 0}` : 'N/A',
-            valueColorClass: 'text-gray-800',
-            bgColorClass: 'bg-green-50',
-            borderColorClass: 'border-green-100',
-          },
-          {
-            title: 'Active Services',
-            icon: 'fa-briefcase',
-            iconColorClass: 'text-blue-600',
-            value: `${data.activeServiceCount || 0} Active`,
-            valueColorClass: 'text-blue-600',
-            bgColorClass: 'bg-blue-50',
-            borderColorClass: 'border-blue-100',
-          },
-        ],
-        detailsText: 'Manage All',
-        detailsLinkOrCallback: '/availability',
+        label: 'Avg Booking Value',
+        value: (bookings.averageBookingValue ?? 0).toLocaleString('en-IN', { maximumFractionDigits: 0 }),
+        unit: '₹',
+        icon: 'fa-solid fa-receipt',
+        tone: 'neutral',
       },
-
     ];
   }
 
-  private _formatNextSlot(slot: { from: string; to: string, date: string }): string {
-    if (!slot?.from || !slot?.to || !slot?.date) return 'No upcoming slot';
-
-    const baseDate = new Date(slot.date);
-
-    // Extract LOCAL date parts
-    const year = baseDate.getFullYear();
-    const month = String(baseDate.getMonth() + 1).padStart(2, '0');
-    const day = String(baseDate.getDate()).padStart(2, '0');
-
-    const from = new Date(`${year}-${month}-${day}T${slot.from}`);
-    const to = new Date(`${year}-${month}-${day}T${slot.to}`);
-
-    if (isNaN(from.getTime()) || isNaN(to.getTime())) {
-      return 'Invalid slot time';
-    }
-
-    return `${baseDate.toDateString()}, 7${from.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+  private _fmtTime(value: string): string {
+    if (!value) return '';
+    const [h, m] = value.split(':');
+    if (!h) return value;
+    const date = new Date();
+    date.setHours(Number(h), Number(m || 0), 0, 0);
+    return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
   }
-
 
   ngOnDestroy(): void {
     this._destroy$.next();

--- a/src/app/modules/shared/components/provider/dashboard/dashboard-attention-card/dashboard-attention-card.component.html
+++ b/src/app/modules/shared/components/provider/dashboard/dashboard-attention-card/dashboard-attention-card.component.html
@@ -1,0 +1,35 @@
+<div class="h-full rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
+    <div class="mb-5 flex items-center justify-between">
+        <h2 class="text-base font-semibold text-slate-900">Needs Attention</h2>
+        <div class="flex h-9 w-9 items-center justify-center rounded-lg bg-amber-50 text-amber-600">
+            <i class="fa-solid fa-bell"></i>
+        </div>
+    </div>
+
+    <ng-container *ngIf="items.length > 0; else clear">
+        <ul class="space-y-3">
+            <li *ngFor="let item of items" class="flex items-center justify-between gap-3 rounded-lg border border-slate-100 bg-slate-50/50 p-3">
+                <div class="flex items-center gap-3">
+                    <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md" [ngClass]="toneClass[item.tone]">
+                        <i [class]="item.icon" class="text-xs"></i>
+                    </div>
+                    <p class="text-sm font-medium text-slate-700">{{ item.title }}</p>
+                </div>
+                <a [routerLink]="item.link"
+                    class="shrink-0 text-xs font-semibold text-emerald-700 hover:text-emerald-800 focus:outline-none focus:underline">
+                    {{ item.linkLabel }}
+                </a>
+            </li>
+        </ul>
+    </ng-container>
+
+    <ng-template #clear>
+        <div class="flex flex-col items-center justify-center py-10 text-center">
+            <div class="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-emerald-50 text-emerald-500">
+                <i class="fa-solid fa-circle-check text-xl"></i>
+            </div>
+            <p class="text-sm font-semibold text-slate-700">You're all caught up</p>
+            <p class="mt-1 text-xs text-slate-500">Nothing needs your attention right now.</p>
+        </div>
+    </ng-template>
+</div>

--- a/src/app/modules/shared/components/provider/dashboard/dashboard-attention-card/dashboard-attention-card.component.ts
+++ b/src/app/modules/shared/components/provider/dashboard/dashboard-attention-card/dashboard-attention-card.component.ts
@@ -1,0 +1,107 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+
+interface AttentionItem {
+    id: string;
+    tone: 'amber' | 'red' | 'slate';
+    icon: string;
+    title: string;
+    link: string[];
+    linkLabel: string;
+}
+
+@Component({
+    selector: 'app-dashboard-attention-card',
+    standalone: true,
+    imports: [CommonModule, RouterLink],
+    templateUrl: './dashboard-attention-card.component.html',
+})
+export class DashboardAttentionCardComponent {
+    @Input() pendingCount = 0;
+    @Input() cancelledCount = 0;
+    @Input() upcomingCount = 0;
+    @Input() activeServiceCount = 0;
+    @Input() verificationVerified = true;
+    @Input() hasSubscription = true;
+
+    get items(): AttentionItem[] {
+        const list: AttentionItem[] = [];
+
+        if (!this.verificationVerified) {
+            list.push({
+                id: 'verify',
+                tone: 'amber',
+                icon: 'fa-solid fa-id-card',
+                title: 'Complete your document verification',
+                link: ['/provider/profiles'],
+                linkLabel: 'Verify',
+            });
+        }
+
+        if (!this.hasSubscription) {
+            list.push({
+                id: 'subscribe',
+                tone: 'amber',
+                icon: 'fa-solid fa-crown',
+                title: 'Choose a subscription plan',
+                link: ['/provider/plans'],
+                linkLabel: 'Subscribe',
+            });
+        }
+
+        if (this.pendingCount > 0) {
+            list.push({
+                id: 'pending',
+                tone: 'amber',
+                icon: 'fa-solid fa-hourglass-half',
+                title: `${this.pendingCount} booking request${this.pendingCount > 1 ? 's are' : ' is'} pending`,
+                link: ['/provider/bookings'],
+                linkLabel: 'Review',
+            });
+        }
+
+        if (this.cancelledCount > 0) {
+            list.push({
+                id: 'cancelled',
+                tone: 'red',
+                icon: 'fa-solid fa-xmark-circle',
+                title: `${this.cancelledCount} booking${this.cancelledCount > 1 ? 's' : ''} were cancelled`,
+                link: ['/provider/bookings'],
+                linkLabel: 'View',
+            });
+        }
+
+        if (this.upcomingCount === 0) {
+            list.push({
+                id: 'upcoming',
+                tone: 'slate',
+                icon: 'fa-solid fa-calendar-day',
+                title: 'No upcoming bookings',
+                link: ['/provider/availability'],
+                linkLabel: 'Manage',
+            });
+        }
+
+        if (this.activeServiceCount === 0) {
+            list.push({
+                id: 'services',
+                tone: 'slate',
+                icon: 'fa-solid fa-briefcase',
+                title: 'No active services',
+                link: ['/provider/manage-services'],
+                linkLabel: 'Add services',
+            });
+        }
+
+        return list;
+    }
+
+    get toneClass(): Record<string, string> {
+        return {
+            amber: 'bg-amber-50 text-amber-700',
+            red: 'bg-red-50 text-red-700',
+            slate: 'bg-slate-50 text-slate-600',
+        };
+    }
+}

--- a/src/app/modules/shared/components/provider/dashboard/dashboard-availability-card/dashboard-availability-card.component.html
+++ b/src/app/modules/shared/components/provider/dashboard/dashboard-availability-card/dashboard-availability-card.component.html
@@ -1,0 +1,28 @@
+<div class="h-full rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
+    <div class="mb-4 flex items-center justify-between">
+        <h2 class="text-base font-semibold text-slate-900">Availability</h2>
+        <div class="flex h-9 w-9 items-center justify-center rounded-lg bg-emerald-50 text-emerald-600">
+            <i class="fa-solid fa-clock"></i>
+        </div>
+    </div>
+
+    <dl class="space-y-4">
+        <div>
+            <dt class="text-xs font-medium uppercase tracking-wide text-slate-500">Working hours</dt>
+            <dd class="mt-1 text-lg font-bold text-slate-900">{{ workingHoursLabel }}</dd>
+        </div>
+        <div>
+            <dt class="text-xs font-medium uppercase tracking-wide text-slate-500">Active services</dt>
+            <dd class="mt-1 text-lg font-bold text-slate-900">{{ activeServiceCount }}</dd>
+        </div>
+        <div>
+            <dt class="text-xs font-medium uppercase tracking-wide text-slate-500">Next booking</dt>
+            <dd class="mt-1 text-sm font-semibold text-emerald-700">{{ nextBookingTime || 'No upcoming booking' }}</dd>
+        </div>
+    </dl>
+
+    <a routerLink="/provider/availability"
+        class="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-2.5 text-sm font-medium text-emerald-700 transition-colors hover:bg-emerald-100 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2">
+        Manage Availability
+    </a>
+</div>

--- a/src/app/modules/shared/components/provider/dashboard/dashboard-availability-card/dashboard-availability-card.component.ts
+++ b/src/app/modules/shared/components/provider/dashboard/dashboard-availability-card/dashboard-availability-card.component.ts
@@ -1,0 +1,30 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+
+@Component({
+    selector: 'app-dashboard-availability-card',
+    standalone: true,
+    imports: [CommonModule, RouterLink],
+    templateUrl: './dashboard-availability-card.component.html',
+})
+export class DashboardAvailabilityCardComponent {
+    @Input() workingHours: { time: { from: string; to: string } } | null = null;
+    @Input() activeServiceCount = 0;
+    @Input() nextBookingTime: string | null = null;
+
+    get workingHoursLabel(): string {
+        const wh = this.workingHours?.time;
+        if (!wh?.from || !wh?.to) return 'Not set';
+        return `${this._fmtTime(wh.from)} – ${this._fmtTime(wh.to)}`;
+    }
+
+    private _fmtTime(value: string): string {
+        if (!value) return '';
+        const [h, m] = value.split(':');
+        if (!h) return value;
+        const date = new Date();
+        date.setHours(Number(h), Number(m || 0), 0, 0);
+        return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+    }
+}

--- a/src/app/modules/shared/components/provider/dashboard/dashboard-header/dashboard-header.component.html
+++ b/src/app/modules/shared/components/provider/dashboard/dashboard-header/dashboard-header.component.html
@@ -1,0 +1,22 @@
+<div class="flex flex-wrap items-end justify-between gap-4">
+    <div>
+        <h1 class="text-3xl font-bold text-slate-900">{{ greeting }}, {{ providerName }}</h1>
+        <p class="mt-1 text-sm text-slate-500">{{ formattedDate }}</p>
+        <p class="mt-2 text-sm text-slate-600">
+            <ng-container *ngIf="upcomingCount > 0">
+                You have <span class="font-semibold text-emerald-700">{{ upcomingCount }}</span> upcoming
+                booking{{ upcomingCount > 1 ? 's' : '' }}.
+            </ng-container>
+            <ng-container *ngIf="nextBookingTime; else clearSchedule">
+                Next booking at <span class="font-semibold text-emerald-700">{{ nextBookingTime }}</span>.
+            </ng-container>
+            <ng-template #clearSchedule>Your schedule is currently clear.</ng-template>
+        </p>
+    </div>
+
+    <a routerLink="/provider/bookings"
+        class="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-4 py-2.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2">
+        <i class="fa-solid fa-calendar-check"></i>
+        View Bookings
+    </a>
+</div>

--- a/src/app/modules/shared/components/provider/dashboard/dashboard-header/dashboard-header.component.ts
+++ b/src/app/modules/shared/components/provider/dashboard/dashboard-header/dashboard-header.component.ts
@@ -1,0 +1,33 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+
+@Component({
+    selector: 'app-dashboard-header',
+    standalone: true,
+    imports: [CommonModule, RouterLink],
+    templateUrl: './dashboard-header.component.html',
+})
+export class DashboardHeaderComponent {
+    @Input() providerName = 'Provider';
+    @Input() upcomingCount = 0;
+    @Input() nextBookingTime: string | null = null;
+
+    today = new Date();
+
+    get greeting(): string {
+        const hour = this.today.getHours();
+        if (hour < 12) return 'Good morning';
+        if (hour < 17) return 'Good afternoon';
+        return 'Good evening';
+    }
+
+    get formattedDate(): string {
+        return this.today.toLocaleDateString('en-US', {
+            weekday: 'long',
+            month: 'long',
+            day: 'numeric',
+            year: 'numeric',
+        });
+    }
+}

--- a/src/app/modules/shared/components/provider/dashboard/dashboard-performance-card/dashboard-performance-card.component.html
+++ b/src/app/modules/shared/components/provider/dashboard/dashboard-performance-card/dashboard-performance-card.component.html
@@ -1,0 +1,33 @@
+<div class="h-full rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
+    <div class="mb-5 flex items-center justify-between">
+        <h2 class="text-base font-semibold text-slate-900">Performance</h2>
+        <div class="flex h-9 w-9 items-center justify-center rounded-lg bg-emerald-50 text-emerald-600">
+            <i class="fa-solid fa-chart-line"></i>
+        </div>
+    </div>
+
+    <div class="flex items-center gap-3">
+        <div class="flex items-center gap-1 text-amber-500">
+            <i class="fa-solid fa-star"></i>
+            <span class="text-2xl font-bold text-slate-900">{{ avgRating.toFixed(1) }}<span class="text-base font-semibold text-slate-400">★</span></span>
+        </div>
+    </div>
+    <p class="mt-1 text-xs text-slate-500">{{ ratingLabel }}</p>
+    <p *ngIf="totalReviews > 0" class="text-xs text-slate-400">{{ totalReviews }} review{{ totalReviews > 1 ? 's' : '' }}</p>
+
+    <div class="mt-5 border-t border-slate-100 pt-4">
+        <div class="flex items-end justify-between">
+            <div>
+                <p class="text-xs font-medium uppercase tracking-wide text-slate-500">Completion rate</p>
+                <p class="mt-1 text-2xl font-bold text-emerald-700">{{ completionRate.toFixed(1) }}%</p>
+            </div>
+        </div>
+        <p class="mt-1 text-xs text-slate-500">{{ completionLabel }}</p>
+    </div>
+
+    <a routerLink="/provider/performance"
+        class="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-slate-200 px-4 py-2.5 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2">
+        View Analytics
+        <i class="fa-solid fa-arrow-right"></i>
+    </a>
+</div>

--- a/src/app/modules/shared/components/provider/dashboard/dashboard-performance-card/dashboard-performance-card.component.ts
+++ b/src/app/modules/shared/components/provider/dashboard/dashboard-performance-card/dashboard-performance-card.component.ts
@@ -1,0 +1,29 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+
+@Component({
+    selector: 'app-dashboard-performance-card',
+    standalone: true,
+    imports: [CommonModule, RouterLink],
+    templateUrl: './dashboard-performance-card.component.html',
+})
+export class DashboardPerformanceCardComponent {
+    @Input() avgRating = 0;
+    @Input() completionRate = 0;
+    @Input() totalReviews = 0;
+
+    get ratingLabel(): string {
+        if (this.avgRating >= 4.5) return 'Excellent customer rating';
+        if (this.avgRating >= 4) return 'Great customer rating';
+        if (this.avgRating >= 3) return 'Good customer rating';
+        if (this.avgRating > 0) return 'Average customer rating';
+        return 'No rating yet';
+    }
+
+    get completionLabel(): string {
+        if (this.completionRate === 0) return 'No bookings completed yet';
+        if (this.completionRate >= 90) return 'Strong completion rate';
+        return `${this.completionRate.toFixed(1)}% of bookings completed`;
+    }
+}

--- a/src/app/modules/shared/components/provider/dashboard/dashboard-skeleton/dashboard-skeleton.component.html
+++ b/src/app/modules/shared/components/provider/dashboard/dashboard-skeleton/dashboard-skeleton.component.html
@@ -1,0 +1,67 @@
+<div class="animate-pulse space-y-6" aria-busy="true" aria-label="Loading dashboard">
+    <!-- Header -->
+    <div class="space-y-2">
+        <div class="h-8 w-64 rounded-md bg-slate-200"></div>
+        <div class="h-4 w-48 rounded-md bg-slate-200"></div>
+    </div>
+
+    <!-- KPI cards -->
+    <div class="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
+        <div *ngFor="let k of kpis" class="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
+            <div class="mb-4 h-11 w-11 rounded-xl bg-slate-200"></div>
+            <div class="mb-3 h-3 w-24 rounded bg-slate-200"></div>
+            <div class="h-8 w-28 rounded bg-slate-200"></div>
+        </div>
+    </div>
+
+    <!-- Next booking / availability -->
+    <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <div class="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100 lg:col-span-2">
+            <div class="mb-4 h-4 w-32 rounded bg-slate-200"></div>
+            <div class="mb-4 h-6 w-40 rounded bg-slate-200"></div>
+            <div class="flex items-center gap-3">
+                <div class="h-10 w-10 rounded-full bg-slate-200"></div>
+                <div class="space-y-2">
+                    <div class="h-3 w-32 rounded bg-slate-200"></div>
+                    <div class="h-3 w-24 rounded bg-slate-200"></div>
+                </div>
+            </div>
+        </div>
+        <div class="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
+            <div class="mb-4 h-4 w-24 rounded bg-slate-200"></div>
+            <div class="space-y-3">
+                <div class="h-3 w-32 rounded bg-slate-200"></div>
+                <div class="h-3 w-28 rounded bg-slate-200"></div>
+                <div class="h-3 w-36 rounded bg-slate-200"></div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Recent bookings -->
+    <div class="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
+        <div class="mb-4 h-4 w-36 rounded bg-slate-200"></div>
+        <div class="space-y-3">
+            <div *ngFor="let _ of [0, 1, 2, 3]" class="flex items-center gap-3">
+                <div class="h-9 w-9 rounded-full bg-slate-200"></div>
+                <div class="flex-1 space-y-2">
+                    <div class="h-3 w-40 rounded bg-slate-200"></div>
+                    <div class="h-3 w-24 rounded bg-slate-200"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Performance / actions -->
+    <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <div class="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
+            <div class="mb-4 h-4 w-24 rounded bg-slate-200"></div>
+            <div class="h-8 w-32 rounded bg-slate-200"></div>
+        </div>
+        <div class="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
+            <div class="mb-4 h-4 w-28 rounded bg-slate-200"></div>
+            <div class="grid grid-cols-2 gap-3">
+                <div *ngFor="let a of actions" class="h-16 rounded-lg bg-slate-200"></div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/app/modules/shared/components/provider/dashboard/dashboard-skeleton/dashboard-skeleton.component.ts
+++ b/src/app/modules/shared/components/provider/dashboard/dashboard-skeleton/dashboard-skeleton.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+    selector: 'app-dashboard-skeleton',
+    standalone: true,
+    imports: [CommonModule],
+    templateUrl: './dashboard-skeleton.component.html',
+})
+export class DashboardSkeletonComponent {
+    kpis = [0, 1, 2, 3];
+    actions = [0, 1, 2, 3];
+}

--- a/src/app/modules/shared/components/provider/dashboard/next-booking-card/next-booking-card.component.html
+++ b/src/app/modules/shared/components/provider/dashboard/next-booking-card/next-booking-card.component.html
@@ -1,0 +1,43 @@
+<div class="h-full rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
+    <div class="mb-4 flex items-center justify-between">
+        <h2 class="text-base font-semibold text-slate-900">Next Booking</h2>
+        <div class="flex h-9 w-9 items-center justify-center rounded-lg bg-emerald-50 text-emerald-600">
+            <i class="fa-solid fa-calendar-day"></i>
+        </div>
+    </div>
+
+    <ng-container *ngIf="hasBooking; else empty">
+        <div class="mb-5">
+            <span class="inline-flex items-center rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">
+                {{ bookingDate }}
+            </span>
+        </div>
+
+        <p class="text-2xl font-bold text-slate-900">{{ timeRange }}</p>
+
+        <div class="mt-4 flex items-center gap-3">
+            <img [src]="nextBooking!.customer.avatar || 'assets/images/profile_placeholder.jpg'" referencePolicy="no-refer"
+                alt="Customer" class="h-10 w-10 rounded-full object-cover ring-2 ring-slate-100" loading="lazy"
+                (error)="onAvatarError($event)" />
+            <div>
+                <p class="text-sm font-semibold text-slate-900">{{ customerName }}</p>
+                <p class="text-xs text-slate-500">{{ serviceName }}</p>
+            </div>
+        </div>
+
+        <a routerLink="/provider/bookings"
+            class="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-2.5 text-sm font-medium text-emerald-700 transition-colors hover:bg-emerald-100 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2">
+            View Booking
+        </a>
+    </ng-container>
+
+    <ng-template #empty>
+        <div class="flex flex-col items-center justify-center py-10 text-center">
+            <div class="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-slate-100 text-slate-400">
+                <i class="fa-solid fa-calendar-xmark text-xl"></i>
+            </div>
+            <p class="text-sm font-semibold text-slate-700">No upcoming booking</p>
+            <p class="mt-1 text-xs text-slate-500">Your schedule is currently clear.</p>
+        </div>
+    </ng-template>
+</div>

--- a/src/app/modules/shared/components/provider/dashboard/next-booking-card/next-booking-card.component.ts
+++ b/src/app/modules/shared/components/provider/dashboard/next-booking-card/next-booking-card.component.ts
@@ -1,0 +1,55 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { IUpcomingBooking } from '../../../../../../core/models/dashboard.model';
+
+@Component({
+    selector: 'app-next-booking-card',
+    standalone: true,
+    imports: [CommonModule, RouterLink],
+    templateUrl: './next-booking-card.component.html',
+})
+export class NextBookingCardComponent {
+    @Input() nextBooking: IUpcomingBooking | null = null;
+    @Input() nextAvailableSlot: { from: string; to: string; date: string } | null = null;
+
+    get hasBooking(): boolean {
+        return !!this.nextBooking;
+    }
+
+    get bookingDate(): string {
+        const d = new Date(this.nextBooking!.slot.date);
+        if (isNaN(d.getTime())) return '';
+        const today = new Date();
+        const tomorrow = new Date();
+        tomorrow.setDate(today.getDate() + 1);
+        if (d.toDateString() === today.toDateString()) return 'Today';
+        if (d.toDateString() === tomorrow.toDateString()) return 'Tomorrow';
+        return d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+    }
+
+    get timeRange(): string {
+        const slot = this.nextBooking!.slot;
+        return `${this._fmtTime(slot.from)} – ${this._fmtTime(slot.to)}`;
+    }
+
+    get customerName(): string {
+        return this.nextBooking!.customer.fullname || this.nextBooking!.customer.username || 'Customer';
+    }
+
+    get serviceName(): string {
+        return this.nextBooking!.service.name || this.nextBooking!.service.category || 'Service';
+    }
+
+    onAvatarError(event: Event): void {
+        (event.target as HTMLImageElement).src = 'assets/images/profile_placeholder.jpg';
+    }
+
+    private _fmtTime(value: string): string {        if (!value) return '';
+        const [h, m] = value.split(':');
+        if (!h) return value;
+        const date = new Date();
+        date.setHours(Number(h), Number(m || 0), 0, 0);
+        return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+    }
+}

--- a/src/app/modules/shared/components/provider/dashboard/recent-bookings-preview/recent-bookings-preview.component.html
+++ b/src/app/modules/shared/components/provider/dashboard/recent-bookings-preview/recent-bookings-preview.component.html
@@ -1,0 +1,88 @@
+<div class="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
+    <div class="mb-4 flex items-center justify-between">
+        <div>
+            <h2 class="text-base font-semibold text-slate-900">Recent Bookings</h2>
+            <p class="text-xs text-slate-500">Your latest booking activity</p>
+        </div>
+        <a routerLink="/provider/bookings"
+            class="inline-flex items-center gap-1.5 text-sm font-semibold text-emerald-700 hover:text-emerald-800 focus:outline-none focus:underline">
+            View all
+            <i class="fa-solid fa-arrow-right"></i>
+        </a>
+    </div>
+
+    <ng-container *ngIf="hasBookings; else empty">
+        <!-- Desktop table -->
+        <div class="hidden overflow-x-auto md:block">
+            <table class="w-full text-left">
+                <thead>
+                    <tr class="border-b border-slate-100 text-xs font-medium uppercase tracking-wide text-slate-500">
+                        <th class="py-3 pr-4">Customer / Service</th>
+                        <th class="py-3 pr-4">Date</th>
+                        <th class="py-3 pr-4">Amount</th>
+                        <th class="py-3">Status</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-slate-50">
+                    <tr *ngFor="let booking of bookings" class="transition-colors hover:bg-slate-50/50">
+                        <td class="py-3 pr-4">
+                            <div class="flex items-center gap-3">
+                                <img [src]="booking.customer.avatar || 'assets/images/profile_placeholder.jpg'"
+                                    alt="Customer" class="h-9 w-9 rounded-full object-cover ring-2 ring-slate-100" loading="lazy"
+                                    (error)="onAvatarError($event)" />
+                                <div>
+                                    <p class="text-sm font-semibold text-slate-900">{{ customerName(booking) }}</p>
+                                    <p class="text-xs text-slate-500">{{ serviceName(booking) }}</p>
+                                </div>
+                            </div>
+                        </td>
+                        <td class="py-3 pr-4">
+                            <p class="text-sm font-medium text-slate-700">{{ getDate(booking.date) }}</p>
+                            <p class="text-xs text-slate-500">{{ getTime(booking.date) }}</p>
+                        </td>
+                        <td class="py-3 pr-4 text-sm font-semibold text-slate-900">₹{{ booking.amount.toLocaleString('en-IN', { maximumFractionDigits: 2 }) }}</td>
+                        <td class="py-3">
+                            <span class="inline-flex rounded-full px-2.5 py-1 text-xs font-semibold" [ngClass]="statusClass(booking.status)">
+                                {{ booking.status.replace('_', ' ') }}
+                            </span>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <!-- Mobile stacked cards -->
+        <div class="space-y-3 md:hidden">
+            <div *ngFor="let booking of bookings" class="rounded-lg border border-slate-100 bg-slate-50/40 p-3">
+                <div class="flex items-start justify-between gap-3">
+                    <div class="flex items-center gap-2.5">
+                        <img [src]="booking.customer.avatar || 'assets/images/profile_placeholder.jpg'"
+                            alt="Customer" class="h-8 w-8 rounded-full object-cover ring-2 ring-slate-100" loading="lazy"
+                            (error)="onAvatarError($event)" />
+                        <div>
+                            <p class="text-sm font-semibold text-slate-900">{{ customerName(booking) }}</p>
+                            <p class="text-xs text-slate-500">{{ serviceName(booking) }}</p>
+                        </div>
+                    </div>
+                    <span class="inline-flex shrink-0 rounded-full px-2 py-0.5 text-xs font-semibold" [ngClass]="statusClass(booking.status)">
+                        {{ booking.status.replace('_', ' ') }}
+                    </span>
+                </div>
+                <div class="mt-2 flex items-center justify-between text-xs text-slate-500">
+                    <span><i class="fa-solid fa-calendar-day mr-1"></i>{{ getDate(booking.date) }} · {{ getTime(booking.date) }}</span>
+                    <span class="font-semibold text-slate-700">₹{{ booking.amount.toLocaleString('en-IN', { maximumFractionDigits: 2 }) }}</span>
+                </div>
+            </div>
+        </div>
+    </ng-container>
+
+    <ng-template #empty>
+        <div class="flex flex-col items-center justify-center py-10 text-center">
+            <div class="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-slate-100 text-slate-400">
+                <i class="fa-solid fa-calendar-xmark text-xl"></i>
+            </div>
+            <p class="text-sm font-semibold text-slate-700">No bookings yet</p>
+            <p class="mt-1 text-xs text-slate-500">Your recent bookings will appear here.</p>
+        </div>
+    </ng-template>
+</div>

--- a/src/app/modules/shared/components/provider/dashboard/recent-bookings-preview/recent-bookings-preview.component.ts
+++ b/src/app/modules/shared/components/provider/dashboard/recent-bookings-preview/recent-bookings-preview.component.ts
@@ -1,0 +1,57 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { IDashboardRecentBooking } from '../../../../../../core/models/dashboard.model';
+
+@Component({
+    selector: 'app-recent-bookings-preview',
+    standalone: true,
+    imports: [CommonModule, RouterLink],
+    templateUrl: './recent-bookings-preview.component.html',
+})
+export class RecentBookingsPreviewComponent {
+    @Input() bookings: IDashboardRecentBooking[] = [];
+
+    get hasBookings(): boolean {
+        return this.bookings.length > 0;
+    }
+
+    getDate(date: string): string {
+        const d = new Date(date);
+        if (isNaN(d.getTime())) return '';
+        const today = new Date();
+        const tomorrow = new Date();
+        tomorrow.setDate(today.getDate() + 1);
+        if (d.toDateString() === today.toDateString()) return 'Today';
+        if (d.toDateString() === tomorrow.toDateString()) return 'Tomorrow';
+        return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    }
+
+    getTime(date: string): string {
+        const d = new Date(date);
+        if (isNaN(d.getTime())) return '';
+        return d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+    }
+
+    statusClass(status: string): string {
+        switch (status) {
+            case 'completed': return 'bg-emerald-100 text-emerald-700';
+            case 'pending': return 'bg-amber-100 text-amber-700';
+            case 'in_progress': return 'bg-blue-100 text-blue-700';
+            case 'cancelled': return 'bg-red-100 text-red-700';
+            default: return 'bg-slate-100 text-slate-600';
+        }
+    }
+
+    customerName(b: IDashboardRecentBooking): string {
+        return b.customer.fullname || b.customer.username || 'Customer';
+    }
+
+    serviceName(b: IDashboardRecentBooking): string {
+        return b.service.name || b.service.category || 'Service';
+    }
+
+    onAvatarError(event: Event): void {
+        (event.target as HTMLImageElement).src = 'assets/images/profile_placeholder.jpg';
+    }
+}

--- a/src/app/modules/shared/partials/sections/provider/sidebar/provider-sidebar.component.html
+++ b/src/app/modules/shared/partials/sections/provider/sidebar/provider-sidebar.component.html
@@ -42,7 +42,8 @@
       <div class="flex items-center gap-3">
         <!-- Avatar -->
         <div class="relative shrink-0">
-          <img [src]="provider.avatar || '/assets/images/admin-front-image.png'" referrerpolicy="no-referrer"
+          <img [src]="provider.avatar && !avatarError ? provider.avatar : '/assets/images/admin-front-image.png'"
+            referrerpolicy="no-referrer" (error)="avatarError = true"
             class="h-10 w-10 rounded-full object-cover border border-gray-200 shadow-sm" alt="Provider Avatar" />
           <span class="absolute bottom-0 right-0 w-2.5 h-2.5 bg-green-500 border-2 border-white rounded-full"></span>
         </div>

--- a/src/app/modules/shared/partials/sections/provider/sidebar/provider-sidebar.component.ts
+++ b/src/app/modules/shared/partials/sections/provider/sidebar/provider-sidebar.component.ts
@@ -19,6 +19,8 @@ export class ProviderSidebarComponent implements OnInit {
 
   providerInfo$ = this.store.select(selectProvider);
 
+  avatarError = false;
+
   sidebarMode: 'expanded' | 'collapsed' | 'hidden' = 'expanded';
   isMobileOpen = false;
   innerWidth = window.innerWidth;


### PR DESCRIPTION
- Make the KPI getters null-safe (d.revenue / d.bookings guarded with ?? {} / ?? 0) so a partial or missing payload can't throw.
- Replace the unreliable provider?.subscriptionID check with SubscriptionService.hasActiveSubscription() so "Choose a subscription plan" only shows when no active subscription exists.
- Remove the redundant Quick Actions section and fold the wallet balance into the Total Earnings KPI description.
- Add an (error) fallback so a broken avatar renders a placeholder instead of a broken <img>.
- Add a welcome onboarding hero for new providers (Get verified / Pick a plan / Add services / Set availability) and show "No bookings completed yet" on the performance card when completionRate === 0.